### PR TITLE
Updates IUS release URL, new git package and glibc dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,12 +29,12 @@ RUN yum remove -y git && \
     rm -rf /var/cache/yum/* /tmp/* /var/tmp/*
 
 # install IUS so we can get a recent version of git
-RUN yum install -y https://centos6.iuscommunity.org/ius-release.rpm && \
+RUN yum install -y https://repo.ius.io/ius-release-el6.rpm && \
     yum clean all && \
     rm -rf /var/cache/yum/* /tmp/* /var/tmp/*
 
 # install modern git
-RUN yum install -y git2u && \
+RUN yum install -y git222 && \
     yum clean all && \
     rm -rf /var/cache/yum/* /tmp/* /var/tmp/*
 
@@ -45,7 +45,7 @@ RUN yum install --disablerepo=updates,extras -y \
     rm -rf /var/cache/yum/* /tmp/* /var/tmp/*
 
 # user space app build dependencies
-RUN yum install --disablerepo=updates,extras -y texinfo \
+RUN yum install --disablerepo=extras -y texinfo \
         glibc-static.x86_64 glibc-static.i686 autogen \
         glibc.i686 glibc-devel.i686 libgcc.i686 && \
     yum clean all && \


### PR DESCRIPTION
- centos6.iuscommunity.org has been deprecated. Using
  repo.ius.io/ius-release-el6.rpm as per the issue below:
  https://github.com/iusrepo/announce/issues/18
- git2u package does not exist anymore in the ius repo.
  As per the issue below using new name with major/minor number:
  https://github.com/iusrepo/wishlist/issues/241
- There was an issue with the dependency for glibc.i686:
  nss-softokn-freebl.i686
  the glibc x86_64 packages needed updating and so removed disabling
  of updates just for the glibc packages.