### PR TITLE
centos: upgrade to centos 6.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM centos:6.7
+FROM centos:6.10
 MAINTAINER Star Lab <support@starlab.io>
 
 RUN mkdir /source
 
 # modify CentOS repo URL following
 # End-of-Life deadline
-ARG DISTROVER=6.7
+ARG DISTROVER=6.10
 RUN sed -i "s/^mirrorlist.*$/baseurl=http:\/\/vault.centos.org\/${DISTROVER}\/os\/\$basearch\//g" /etc/yum.repos.d/CentOS-Base.repo
 
 # update certificates


### PR DESCRIPTION
The centos6 container began to fail compilation
after the root cert expiration in Aug.  Needed to
upgrade the base distribution to 6.10 to get it
compiling once again.