### PR TITLE
Update URL with www to resolve cert issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN wget https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_V
     rm -rf shellcheck-${SHELLCHECK_VER}
 
 # Download, build and install Python 3.6.8 and upgrade pip3
-RUN wget https://python.org/ftp/python/3.6.8/Python-3.6.8.tar.xz && \
+RUN wget https://www.python.org/ftp/python/3.6.8/Python-3.6.8.tar.xz && \
     tar xfJ Python-3.6.8.tar.xz
 WORKDIR Python-3.6.8
 RUN ./configure --prefix=/usr/local --enable-shared LDFLAGS="-Wl,-rpath /usr/local/lib" && \


### PR DESCRIPTION
Change `python.org` to `www.python.org` to resolve the following error:

```
Step 18/33 : RUN wget https://python.org/ftp/python/3.6.8/Python-3.6.8.tar.xz &&     tar xfJ Python-3.6.8.tar.xz
 ---> Running in df72dfbc9b38
--2021-11-04 15:57:52--  https://python.org/ftp/python/3.6.8/Python-3.6.8.tar.xz
Resolving python.org... 138.197.63.241
Connecting to python.org|138.197.63.241|:443... connected.
ERROR: cannot verify python.org's certificate, issued by `/C=US/O=Let\'s Encrypt/CN=R3':
  Issued certificate has expired.
To connect to python.org insecurely, use `--no-check-certificate'.
The command '/bin/sh -c wget https://python.org/ftp/python/3.6.8/Python-3.6.8.tar.xz &&     tar xfJ Python-3.6.8.tar.xz' returned a non-zero code: 5
```